### PR TITLE
Use plain string.find over pattern matching

### DIFF
--- a/train-log_1.1.8/gui/events_table.lua
+++ b/train-log_1.1.8/gui/events_table.lua
@@ -237,7 +237,7 @@ local function matches_filter(result, filters)
         end
         if not matches_station and event.station then
             local station_name = event.station.valid and event.station.backer_name or ""
-            if station_name:lower():find(filters.station_name) then
+            if station_name:lower():find(filters.station_name, 1, true) then
                 matches_station = true
             end
         end


### PR DESCRIPTION
This makes the station filter work with [item=...] specifiers

Before:

![Screenshot_20240123_231927](https://github.com/Zomis/FactorioMods/assets/7288995/7ad4e91b-2b80-47e7-9450-3d59cd688c67)

After:

![Screenshot_20240125_165547](https://github.com/Zomis/FactorioMods/assets/7288995/5a8063cf-5cf4-4618-8dd6-94d15e5cd6b5)

