### PR TITLE
copy-paste-recipe-signals, feature, copying as in the request chest (the number of items required for 30 seconds of work) 

### DIFF
--- a/copy-paste-recipe-signals_1.3.0/locale/en/values.cfg
+++ b/copy-paste-recipe-signals_1.3.0/locale/en/values.cfg
@@ -4,6 +4,7 @@ copy-paste-recipe-signals-product-multiplier=Product multiplier
 copy-paste-recipe-signals-include-ticks=Include ticks
 copy-paste-recipe-signals-include-seconds=Include seconds
 copy-paste-recipe-time-includes-modules=Consider assembling machine speed
+copy-paste-recipe-copy-item-count-as-request-chest=Сopy the number of items the same way as in the request chest
 copy-paste-recipe-time-paste-product-arithmetic=Copy product to arithmetic combinator
 copy-paste-recipe-time-paste-product-decider=Copy product to decider combinator
 
@@ -13,5 +14,6 @@ copy-paste-recipe-signals-product-multiplier=Multiplies all products with this a
 copy-paste-recipe-signals-include-ticks=Add the signal T for the number of ticks the recipe takes (1 second = 60 ticks)
 copy-paste-recipe-signals-include-seconds=Add the signal S for the number of seconds the recipe takes
 copy-paste-recipe-time-includes-modules=The signals T and S will be adjusted according to the speed of the machine (including speed modules)
+copy-paste-recipe-copy-item-count-as-request-chest=Copies the number of items in the same way as in the vanilla request chest(multiplier affected), i.e. to request enough items for a recipe to keep the machine running for 30 seconds.
 copy-paste-recipe-time-paste-product-arithmetic="Copy first output product to arithmetic combinator's first signal"
 copy-paste-recipe-time-paste-product-decider="Copy first output product to decider combinator's first signal"

--- a/copy-paste-recipe-signals_1.3.0/settings.lua
+++ b/copy-paste-recipe-signals_1.3.0/settings.lua
@@ -53,7 +53,7 @@ data:extend({
         name = "copy-paste-recipe-copy-item-count-as-request-chest",
         setting_type = "runtime-per-user",
         order = "dz",
-        default_value = true
+        default_value = false
     }
 })
 data:extend({

--- a/copy-paste-recipe-signals_1.3.0/settings.lua
+++ b/copy-paste-recipe-signals_1.3.0/settings.lua
@@ -50,9 +50,18 @@ data:extend({
 data:extend({
     {
         type = "bool-setting",
+        name = "copy-paste-recipe-copy-item-count-as-request-chest",
+        setting_type = "runtime-per-user",
+        order = "dz",
+        default_value = true
+    }
+})
+data:extend({
+    {
+        type = "bool-setting",
         name = "copy-paste-recipe-time-paste-product-arithmetic",
         setting_type = "runtime-per-user",
-        order = "e",    
+        order = "e",
         default_value = true
     }
 })
@@ -65,3 +74,4 @@ data:extend({
         default_value = true
     }
 })
+


### PR DESCRIPTION
The story behind this pull request is very simple. I was building a mall and in order to automatically set a request for a buffer chest, I decided to do it using this mod and combinators, then I discovered that the quantity that fits into the combinator and into the request chest are different.
I didn’t touch the folder name, info.json and changelog.txt, because if I understood correctly from the README, then this should be left to you